### PR TITLE
fixed platform support and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,10 @@ Converting CLI output of the `show version` command from a Cisco IOS-XE device t
 
     {{ cli_output | clay584.genie.parse_genie(command='show version', os='iosxe') }}
 
+For deeper abstraction, you might want to add `platform` to `parse_parse`.
+
+    {{ cli_output | clay584.genie.parse_genie(command='show environment all', os='iosxe', platform='asr1k') }}
+
 The above example would yield the following:
 
     {

--- a/clay584/genie/README.md
+++ b/clay584/genie/README.md
@@ -355,7 +355,7 @@ by their fully qualified name. So, when using the parse_genie filter plugin, you
 "{{ show_cli_output | clay584.genie.parse_genie(command='show version', os='iosxe') }}"
 ```
 
-For deeper abstraction, you might want to add `platform` to `genie_parse`.
+For deeper abstraction, you might want to add `platform` to `parse_genie`.
 
 ```
 "{{ show_cli_output | clay584.genie.parse_genie(command='show environment all', os='iosxe', platform='asr1k') }}"

--- a/clay584/genie/plugins/filter/parse_genie.py
+++ b/clay584/genie/plugins/filter/parse_genie.py
@@ -102,10 +102,11 @@ def parse_genie(cli_output,
         # tb = Testbed()
         if platform:
             device = Device("new_device", os=nos, platform=platform)
+            device.custom.setdefault("abstraction", {})["order"] = ["os", "platform"]
         else:
             device = Device("new_device", os=nos)
+            device.custom.setdefault("abstraction", {})["order"] = ["os"]
 
-        device.custom.setdefault("abstraction", {})["order"] = ["os"]
         device.cli = AttrDict({"execute": None})
 
         # User input checking of the command provided. Does the command have a Genie parser?


### PR DESCRIPTION
I missed one thing to update `custom` field for device object with `platform`. This is the fix.